### PR TITLE
Moving gameobject after we get all the gameobject on the destination.

### DIFF
--- a/backend/src/gameengine/board.ts
+++ b/backend/src/gameengine/board.ts
@@ -292,9 +292,6 @@ export class Board {
     );
     gameObjectsPrev.forEach(g => g.onGameObjectLeft(gameObject, this));
 
-    // Update position of game object
-    gameObject.position = dest;
-
     // Notify game objects in new position that we are entering the new position
     const gameObjectsDest = this.getGameObjectsOnPosition(dest);
     this.logger.debug(
@@ -302,6 +299,10 @@ export class Board {
       "entered",
       JSON.stringify(gameObject.position),
     );
+
+    // Update position of game object
+    gameObject.position = dest;
+
     gameObjectsDest.forEach(g => g.onGameObjectEntered(gameObject, this));
 
     return true;


### PR DESCRIPTION
Bots could not move after the tackle release. They where sent back to the base because  "onGameObjectEntered" was triggered (They entered themselves). Changing  the destination of the gameobject after we have fetched the objects on the destination.