### PR TITLE
Teleports works as expected

### DIFF
--- a/backend/src/gameengine/board.ts
+++ b/backend/src/gameengine/board.ts
@@ -262,12 +262,6 @@ export class Board {
     skipLeaveCheck = false,
     skipEnterCheck = false,
   ): boolean {
-    // Check if the moving object already been here during this request
-    if (gameObject.hasAlreadyBeenHere(dest)) {
-      this.gameObjects.forEach(o => o.clearPositions());
-      return false;
-    }
-
     // Check if we can leave the current position
     if (!(skipLeaveCheck || this.canGameObjectLeave(gameObject, dest))) {
       this.logger.debug("Not allowed to leave");

--- a/backend/src/gameengine/gameobjects/abstract-game-object.spec.ts
+++ b/backend/src/gameengine/gameobjects/abstract-game-object.spec.ts
@@ -62,20 +62,6 @@ describe("multiple positions", () => {
 
     expect(go.previousPosition).toBeNull();
   });
-
-  test("hasAlreadyBeenHere returns true when position has been in path", () => {
-    go.position = { x: 2, y: 4 };
-    go.position = { x: 3, y: 5 };
-
-    expect(go.hasAlreadyBeenHere({ x: 2, y: 4 })).toBeTruthy();
-  });
-
-  test("hasAlreadyBeenHere returns false otherwise", () => {
-    go.position = { x: 2, y: 4 };
-    go.position = { x: 3, y: 5 };
-
-    expect(go.hasAlreadyBeenHere({ x: 8, y: 7 })).toBeFalsy();
-  });
 });
 
 test("has null properties by default", () => {

--- a/backend/src/gameengine/gameobjects/abstract-game-object.ts
+++ b/backend/src/gameengine/gameobjects/abstract-game-object.ts
@@ -38,10 +38,6 @@ export abstract class AbstractGameObject {
     return null;
   }
 
-  public hasAlreadyBeenHere(position: IPosition): boolean {
-    return this.positions.some(p => position.x === p.x && position.y === p.y);
-  }
-
   public clearPositions(): void {
     this.positions = [this.position];
   }

--- a/backend/src/gameengine/gameobjects/teleport/teleport.spec.ts
+++ b/backend/src/gameengine/gameobjects/teleport/teleport.spec.ts
@@ -22,7 +22,8 @@ beforeEach(() => {
 });
 
 test("Stepping on a teleporter moves bot to position of paired teleporter", () => {
-  const bot = new BotGameObject({ x: 0, y: 0 });
+  const bot = new BotGameObject({ x: 0, y: 1 });
+  bot.position = { x: 0, y: 0 };
 
   teleporterToEnter.onGameObjectEntered(bot, board);
 

--- a/backend/src/gameengine/gameobjects/teleport/teleport.ts
+++ b/backend/src/gameengine/gameobjects/teleport/teleport.ts
@@ -24,7 +24,12 @@ export class TeleportGameObject extends AbstractGameObject {
     const otherTeleport = teleports.find(
       t => t.pairId === this.pairId && t !== this,
     );
-
+    if (
+      bot.previousPosition.x === otherTeleport.position.x &&
+      bot.previousPosition.y === otherTeleport.position.y
+    ) {
+      return;
+    }
     if (board.trySetGameObjectPosition(bot, otherTeleport.position)) {
       board.notifyGameObjectEvent(this, "TELEPORTED");
     }


### PR DESCRIPTION
The teleports work now as expected.

You can teleport from one teleporter to the other one . Step outside the teleporter and then teleport back again.

I have added a check in onGameObjectEntered (teleport) so the bot won't get teleported back and forward forever.

I removed hasAlreadyBeen here so I don't have to do three /move to go from:

{x:0, y:0} -> {x:0, y:1} -> {x:0, y:0}
You could not go back to an old position before in one /move, because hasAlreadyBeenHere rejected the move and cleared the positions and then you could go back if you did a second /move.

We don't need this control because you should be able to go back to previous positions.

Closes #110 

