### PR TITLE
Fix resizing of game board to match screen size

### DIFF
--- a/frontend/src/blocks/Board/Cell.js
+++ b/frontend/src/blocks/Board/Cell.js
@@ -2,19 +2,25 @@ import styled from "styled-components";
 
 export default styled.div`
   border: 1px solid #707070;
-  width: ${props => `${props.smallCellSize}vw`};
-  height: ${props => `${props.smallCellSize}vw`};
+  width: ${props => `calc(100% / ${props.width})`};
   display: flex;
-  max-width: 3.5vw;
-  max-height: 3.5vw;
   justify-content: center;
   align-items: center;
   flex-direction: column;
+  position: relative;
 
-  @media only screen and (max-width: 1050px) {
-    max-width: initial;
-    max-height: initial;
-    width: ${props => `${props.bigCellSize}vw`};
-    height: ${props => `${props.bigCellSize}vw`};
+  > div {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    justify-content: center;
+    position: absolute;
+    width: 100%;
+  }
+
+  &::after {
+    content: "";
+    padding-bottom: 100%;
   }
 `;

--- a/frontend/src/blocks/Board/CharacterName.js
+++ b/frontend/src/blocks/Board/CharacterName.js
@@ -12,6 +12,6 @@ export default styled.div`
   margin: 0;
 
   @media only screen and (max-width: 900px) {
-    font-size: 65%;
+    font-size: 55%;
   }
 `;

--- a/frontend/src/blocks/Board/Row.js
+++ b/frontend/src/blocks/Board/Row.js
@@ -3,4 +3,5 @@ import styled from "styled-components";
 export default styled.div`
   display: flex;
   flex-direction: row;
+  width: 100%;
 `;

--- a/frontend/src/blocks/Board/index.js
+++ b/frontend/src/blocks/Board/index.js
@@ -5,18 +5,25 @@ import CharacterName from "./CharacterName";
 import CharacterImg from "./CharacterImg";
 
 const Board = styled.div`
-  position: sticky;
-  border: 1px solid #707070;
-  top: 40px;
-  height: 100%;
-  border-radius: 4px;
+  align-items: center;
   display: flex;
   flex-direction: column;
-  margin-bottom: 1.5rem;
+  position: relative;
+  width: 70%;
 
-  @media only screen and (max-width: 1050px) {
-    position: initial;
-    top: initial;
+  @media only screen and (max-width: 768px) {
+    width: 100%;
+  }
+
+  &::after {
+    content: "";
+    padding-bottom: 100%;
+  }
+
+  > div {
+    position: absolute;
+    height: 100%;
+    width: 100%;
   }
 `;
 

--- a/frontend/src/blocks/Header/index.js
+++ b/frontend/src/blocks/Header/index.js
@@ -4,16 +4,35 @@ import Title from "./Title";
 import Link from "./Link";
 
 const Header = styled.div`
-  display: flex;
-  width: 90%;
-  justify-content: space-between;
-  align-items: baseline;
-  margin: 1rem auto 2rem auto;
-  height: 3rem;
+  align-items: flex-end;
   border-bottom: 1px solid #e1e1e1;
+  display: flex;
+  height: 3rem;
+  justify-content: center;
+  margin: 1rem auto;
+  width: 90%;
 
-  @media only screen and (max-width: 1050px) {
-    margin-bottom: 1rem;
+  > div {
+    flex: 1;
+    display: flex;
+    height: 100%;
+    justify-content: center;
+  }
+
+  div:first-child > img {
+    margin-right: auto;
+  }
+  div:last-child > div {
+    display: flex;
+    margin-left: auto;
+    gap: 1rem;
+    height: 100%;
+    justify-content: right;
+
+    a {
+      display: inline-block;
+      align-self: center;
+    }
   }
 `;
 

--- a/frontend/src/blocks/Layout/Game.js
+++ b/frontend/src/blocks/Layout/Game.js
@@ -3,6 +3,13 @@ import styled from "styled-components";
 export default styled.div`
   display: flex;
   flex-direction: row;
-  flex-wrap: wrap;
-  justify-content: center;
+  gap: 1rem;
+  height: calc(100% - 5rem);
+  justify-content: space-around;
+  padding: 0 1rem 1.5rem;
+
+  @media only screen and (max-width: 768px) {
+    flex-direction: column;
+    justify-content: flex-start;
+  }
 `;

--- a/frontend/src/blocks/Layout/Tables.js
+++ b/frontend/src/blocks/Layout/Tables.js
@@ -1,15 +1,17 @@
 import styled from "styled-components";
 
 export default styled.div`
+  border: 1px solid #e1e1e1;
+  border-radius: 4px;
   display: flex;
   flex-direction: column;
-  margin-left: 3rem;
+  height: 100%;
+  overflow-y: scroll;
+  padding: 0.5rem;
   width: 30%;
-  max-width: 450px;
 
-  @media only screen and (max-width: 1050px) {
-    width: 90%;
-    max-width: initial;
-    margin-left: initial;
+  @media only screen and (max-width: 768px) {
+    min-height: 600px;
+    width: 100%;
   }
 `;

--- a/frontend/src/blocks/Layout/index.js
+++ b/frontend/src/blocks/Layout/index.js
@@ -5,6 +5,7 @@ import Tables from "./Tables";
 const Layout = styled.div`
   display: flex;
   flex-direction: column;
+  height: 100%;
 `;
 
 Layout.Game = Game;

--- a/frontend/src/blocks/Table/LogoImg.js
+++ b/frontend/src/blocks/Table/LogoImg.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
 export default styled.img`
-  max-height: 100px;
-  max-width: 100px;
+  max-height: 60px;
+  max-width: 60px;
 `;

--- a/frontend/src/blocks/Table/index.js
+++ b/frontend/src/blocks/Table/index.js
@@ -11,6 +11,7 @@ import LogoImg from "./LogoImg";
 const Table = styled.table`
   border-collapse: collapse;
   margin-bottom: 1.5rem;
+  overflow-y: scroll;
 `;
 
 Table.Caption = Caption;

--- a/frontend/src/components/GameBoard.js
+++ b/frontend/src/components/GameBoard.js
@@ -13,6 +13,7 @@ import {
   wall,
   redButton
 } from "../images";
+import { useResize } from "../hooks";
 
 export default ({ rows }) => {
   const decideCharacter = content => {
@@ -50,38 +51,51 @@ export default ({ rows }) => {
   const bigCellSize = (90 / width).toFixed(2);
   const smallCellSize = (60 / width).toFixed(2);
 
-  return (
-    <Board>
-      {rows.map((cells, key) => {
-        return (
-          <Board.Row key={key}>
-            {cells.map((content, key) => {
-              const character = decideCharacter(content);
-              const characterName = decideCharacterName(content);
-              const shouldRotate = content.goName === "Teleporter" ? 1 : 0;
+  const [containerRef, maxWidth] = useResize({
+    root: document.querySelector("#test"),
+    rootMargin: "0px",
+    threshold: 0
+  });
 
-              return (
-                <Board.Cell
-                  key={key}
-                  bigCellSize={bigCellSize}
-                  smallCellSize={smallCellSize}
-                >
-                  {characterName && (
-                    <Board.CharacterName>{characterName}</Board.CharacterName>
-                  )}
-                  {character && (
-                    <Board.CharacterImg
-                      alt="player"
-                      src={character}
-                      rotate={shouldRotate}
-                    />
-                  )}
-                </Board.Cell>
-              );
-            })}
-          </Board.Row>
-        );
-      })}
+  return (
+    <Board id="test">
+      <div ref={containerRef} style={maxWidth}>
+        {rows.map((cells, key) => {
+          return (
+            <Board.Row key={key}>
+              {cells.map((content, key) => {
+                const character = decideCharacter(content);
+                const characterName = decideCharacterName(content);
+                const shouldRotate = content.goName === "Teleporter" ? 1 : 0;
+
+                return (
+                  <Board.Cell
+                    key={key}
+                    width={width}
+                    bigCellSize={bigCellSize}
+                    smallCellSize={smallCellSize}
+                  >
+                    <div>
+                      {characterName && (
+                        <Board.CharacterName>
+                          {characterName}
+                        </Board.CharacterName>
+                      )}
+                      {character && (
+                        <Board.CharacterImg
+                          alt="player"
+                          src={character}
+                          rotate={shouldRotate}
+                        />
+                      )}
+                    </div>
+                  </Board.Cell>
+                );
+              })}
+            </Board.Row>
+          );
+        })}
+      </div>
     </Board>
   );
 };

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -14,16 +14,24 @@ export default () => {
   let location = useLocation();
   return (
     <Header>
-      <Header.Logo alt="etimoLogo" src={etimoLogo} />
-      <Header.Title>Diamonds</Header.Title>
-      {teamsOrGameLink(location)}
-      <Header.Link
-        target="_blank"
-        rel="noopener"
-        href="https://github.com/Etimo/diamonds2"
-      >
-        How to play
-      </Header.Link>
+      <div>
+        <Header.Logo alt="etimoLogo" src={etimoLogo} />
+      </div>
+      <div>
+        <Header.Title>Diamonds</Header.Title>
+      </div>
+      <div>
+        <div>
+          {teamsOrGameLink(location)}
+          <Header.Link
+            target="_blank"
+            rel="noopener"
+            href="https://github.com/Etimo/diamonds2"
+          >
+            How to play
+          </Header.Link>
+        </div>
+      </div>
     </Header>
   );
 };

--- a/frontend/src/hooks/index.js
+++ b/frontend/src/hooks/index.js
@@ -4,6 +4,7 @@ import useBoard from "./useBoard";
 import useBoardIds from "./useBoardIds";
 import useSeasons from "./useSeasons";
 import getCurrentSeason from "./getCurrentSeason";
+import useResize from "./useResize";
 
 export {
   useInterval,
@@ -11,5 +12,6 @@ export {
   useBoard,
   useBoardIds,
   useSeasons,
-  getCurrentSeason
+  getCurrentSeason,
+  useResize
 };

--- a/frontend/src/hooks/useResize.js
+++ b/frontend/src/hooks/useResize.js
@@ -1,0 +1,33 @@
+import { useEffect, useState, useRef } from "react";
+
+export default options => {
+  const containerRef = useRef(null);
+  const [maxWidth, setMaxWidth] = useState({
+    maxWidth: "100%"
+  });
+
+  const callbackFunction = entries => {
+    const [entry] = entries;
+
+    const parent = entry.target.parentElement;
+    if (parent.offsetWidth > parent.offsetHeight) {
+      setMaxWidth({
+        maxWidth: `${parent.offsetHeight}px`
+      });
+    } else {
+      setMaxWidth({
+        maxWidth: `${parent.offsetWidth}px`
+      });
+    }
+  };
+
+  useEffect(() => {
+    const observer = new ResizeObserver(callbackFunction);
+    if (containerRef.current) observer.observe(containerRef.current);
+    return () => {
+      if (containerRef.current) observer.unobserve(containerRef.current);
+    };
+  }, [containerRef, options]);
+
+  return [containerRef, maxWidth];
+};

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -5,7 +5,7 @@ import App from "./App";
 
 const GlobalStyle = createGlobalStyle`
   html, body {
-    height: 100%;
+    height: 100vh;
     margin: 0;
   }
   html {
@@ -15,6 +15,9 @@ const GlobalStyle = createGlobalStyle`
     box-sizing: inherit;
     font-family: 'PT Sans', sans-serif;
     color: #2C3E50;
+  }
+  #root {
+    height: 100%;
   }
 `;
 


### PR DESCRIPTION
Game board did not follow window size when it changed. This PR fixes that and scales the board after window size.
- Updated styling
- Added Resize observer to update max-width to an actual value so the relative values have something to start from.
- Updated breakpoint for "mobile" layout to `max-width: 768px` (iPad width in portrait mode)

fixes #163
fixes #90 