### PR TITLE
fix: Dont allow whitespace in bot name

### DIFF
--- a/backend/src/models/bot-registration.dto.ts
+++ b/backend/src/models/bot-registration.dto.ts
@@ -1,12 +1,10 @@
 import { ApiModelProperty } from "@nestjs/swagger";
-import { PositionDto } from "./position.dto";
 import {
   IsEmail,
   IsString,
-  Min,
-  Max,
-  MinLength,
   MaxLength,
+  MinLength,
+  NotContains,
 } from "class-validator";
 export class BotRegistrationDto {
   @ApiModelProperty({
@@ -22,6 +20,7 @@ export class BotRegistrationDto {
   @IsString()
   @MinLength(1)
   @MaxLength(10)
+  @NotContains(" ", { message: "Bot name can not contain whitespace" })
   readonly botName: string;
 
   @ApiModelProperty({


### PR DESCRIPTION
This PR removes the possibility to have whitespaces in a bot's name.

Solves #200 